### PR TITLE
Format CFBundleShortVersionString to spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,20 @@ function getNewVersionCode(programOpts, versionCode, versionName, resetBuild) {
 }
 
 /**
+ * CFBundleShortVersionString must be a string composed of three period-separated integers.
+ * @private
+ * @param {String} versionName The full version string
+ * @return {String} e.g. returns '1.2.3' for given '1.2.3-beta.1'
+ */
+function getCFBundleShortVersionString(versionName) {
+	const array =
+		versionName && typeof versionName === "string"
+			? versionName.match(/\d*\.\d*.\d*/g)
+			: [];
+	return array[0] ? array[0] : versionName;
+}
+
+/**
  * Determines whether the project is an Expo app or a plain React Native app
  * @private
  * @return {Boolean} true if the project is an Expo app
@@ -428,7 +442,9 @@ function version(program, projectPath) {
 									json,
 									!programOpts.incrementBuild
 										? {
-												CFBundleShortVersionString: appPkg.version
+												CFBundleShortVersionString: getCFBundleShortVersionString(
+													appPkg.version
+												)
 										  }
 										: {},
 									!programOpts.neverIncrementBuild
@@ -607,6 +623,7 @@ function version(program, projectPath) {
 }
 
 module.exports = {
+	getCFBundleShortVersionString: getCFBundleShortVersionString,
 	getDefaults: getDefaults,
 	getPlistFilenames: getPlistFilenames,
 	isExpoProject: isExpoProject,

--- a/index.js
+++ b/index.js
@@ -99,14 +99,14 @@ function getNewVersionCode(programOpts, versionCode, versionName, resetBuild) {
  * CFBundleShortVersionString must be a string composed of three period-separated integers.
  * @private
  * @param {String} versionName The full version string
- * @return {String} e.g. returns '1.2.3' for given '1.2.3-beta.1'
+ * @return {String} e.g. returns '1.2.3' for given '1.2.3-beta.1'. Returns `versionName` if no match is found.
  */
 function getCFBundleShortVersionString(versionName) {
-	const array =
+	const match =
 		versionName && typeof versionName === "string"
 			? versionName.match(/\d*\.\d*.\d*/g)
 			: [];
-	return array[0] ? array[0] : versionName;
+	return match && match[0] ? match[0] : versionName;
 }
 
 /**

--- a/test/shortBundleVerions.js
+++ b/test/shortBundleVerions.js
@@ -40,3 +40,11 @@ test(
 		t.is(v, '1.2.3');
 	}
 );
+
+test(
+	"CFBundleShortVersionString garbage in, garbage out",
+	t => {
+		const v = getCFBundleShortVersionString('garbage');
+		t.is(v, 'garbage');
+	}
+);

--- a/test/shortBundleVerions.js
+++ b/test/shortBundleVerions.js
@@ -1,0 +1,42 @@
+import { getCFBundleShortVersionString } from '../';
+import test from "ava";
+
+test(
+	"CFBundleShortVersionString basic",
+	t => {
+		const v = getCFBundleShortVersionString('1.2.3');
+		t.is(v, '1.2.3');
+	}
+);
+
+test(
+	"CFBundleShortVersionString alpha",
+	t => {
+		const v = getCFBundleShortVersionString('1.2.3-alpha');
+		t.is(v, '1.2.3');
+	}
+);
+
+test(
+	"CFBundleShortVersionString alpha point",
+	t => {
+		const v = getCFBundleShortVersionString('1.2.3-alpha.0');
+		t.is(v, '1.2.3');
+	}
+);
+
+test(
+	"CFBundleShortVersionString dash number",
+	t => {
+		const v = getCFBundleShortVersionString('1.2.3-0');
+		t.is(v, '1.2.3');
+	}
+);
+
+test(
+	"CFBundleShortVersionString extra dot",
+	t => {
+		const v = getCFBundleShortVersionString('1.2.3.0');
+		t.is(v, '1.2.3');
+	}
+);


### PR DESCRIPTION
According to Apple:
> The release version number is a string composed of three period-separated integers.

A fix for #41